### PR TITLE
Provide basic example of custom types

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -22,11 +22,18 @@ export default function App() {
   const [accountLoaded, setaccountLoaded] = useState(false);
   //const WS_PROVIDER = "ws://127.0.0.1:9944";
   const WS_PROVIDER = 'wss://dev-node.substrate.dev:9944';
+  const TYPES = {};
+  //const TYPES = {"MyNumber": "u32"};
+  // More information on constom types
+  // https://github.com/polkadot-js/apps/blob/master/packages/app-settings/src/md/basics.md
 
   useEffect(() => {
     const provider = new WsProvider(WS_PROVIDER);
 
-    ApiPromise.create({ provider })
+    ApiPromise.create({
+      provider,
+      types: TYPES,
+    })
       .then(api => {
         setApi(api);
         api.isReady.then(() => setApiReady(true));

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -24,7 +24,7 @@ export default function App() {
   const WS_PROVIDER = 'wss://dev-node.substrate.dev:9944';
   const TYPES = {};
   //const TYPES = {"MyNumber": "u32"};
-  // More information on constom types
+  // More information on custom types
   // https://github.com/polkadot-js/apps/blob/master/packages/app-settings/src/md/basics.md
 
   useEffect(() => {


### PR DESCRIPTION
Adds a basic example of how a user would specify their own custom types, and makes it explicit that the default types is an empty object, `{}`. It also provides a link to learn more about specifying types. This kind of guiding is already precedented as in:

```
  //const WS_PROVIDER = "ws://127.0.0.1:9944";
  const WS_PROVIDER = 'wss://dev-node.substrate.dev:9944';
```

Motivation:
Most users will be extending this template because they are building a custom runtime module, and most custom modules have custom types, thus most users will need to make this modification. 