### PR TITLE
Add addresses as dependency in Balances.

### DIFF
--- a/src/Balances.jsx
+++ b/src/Balances.jsx
@@ -28,7 +28,7 @@ export default function Balances(props) {
       .catch(console.error);
 
     return () => unsubscribeAll && unsubscribeAll();
-  }, [api.query.balances.freeBalance, setBalances]);
+  }, [api.query.balances.freeBalance, setBalances, addresses]);
 
   return (
     <Grid.Column>


### PR DESCRIPTION
When starting the ui template I get the following linting warning. This PR makes the warning go away. 

```
./src/Balances.jsx
  Line 31:  React Hook useEffect has a missing dependency: 'addresses'. Either include it or remove the dependency array  react-hooks/exhaustive-deps
```



The pr is based on https://stackoverflow.com/q/56992052/4184410 but I'm not a react expert and would like some input about whether this is the correct solution. It seems weird to me to have to add addresses as a dependency when it is a `const` and thus should never change.