### PR TITLE
Don't manually set component value

### DIFF
--- a/src/Extrinsics.jsx
+++ b/src/Extrinsics.jsx
@@ -77,7 +77,6 @@ export default function Metadata(props) {
             selection
             state="addressFrom"
             options={keyringOptions}
-            value={addressFrom}
           />
         </Form.Field>
         <Form.Field>
@@ -90,7 +89,6 @@ export default function Metadata(props) {
             selection
             state="module"
             options={modulesList}
-            value={module}
           />
         </Form.Field>
         <Form.Field>
@@ -103,7 +101,6 @@ export default function Metadata(props) {
             selection
             state="callableFunction"
             options={callableFunctionList}
-            value={callableFunction}
           />
         </Form.Field>
         <Form.Field>
@@ -114,7 +111,6 @@ export default function Metadata(props) {
             placeholder="May not be needed"
             state="input"
             type="text"
-            value={input}
           />
         </Form.Field>
         <Form.Field>

--- a/src/Transfer.jsx
+++ b/src/Transfer.jsx
@@ -45,7 +45,6 @@ export default function Transfer(props) {
             selection
             state="addressFrom"
             options={keyringOptions}
-            value={addressFrom}
           />
         </Form.Field>
         <Form.Field>
@@ -56,7 +55,6 @@ export default function Transfer(props) {
             placeholder="address"
             state="addressTo"
             type="text"
-            value={addressTo}
           />
         </Form.Field>
         <Form.Field>
@@ -66,7 +64,6 @@ export default function Transfer(props) {
             onChange={onChange}
             state="amount"
             type="number"
-            value={amount}
           />
         </Form.Field>
         <Form.Field>

--- a/src/Upgrade.jsx
+++ b/src/Upgrade.jsx
@@ -63,7 +63,6 @@ export default function Transfer(props) {
             selection
             state="addressFrom"
             options={keyringOptions}
-            value={addressFrom}
           />
         </Form.Field>
         <Form.Field>


### PR DESCRIPTION
Form components don't need their value attribute to be manually specified; that happens automatically. This PR corrects that on all four fields of the extrinsics component.

I guess this was copied over from the front-end tutorial code (eg [here](https://github.com/substrate-developer-hub/substrate-front-end/blob/master/part-3-1/src/Transfer.js#L64)).