### PR TITLE
Make default functions names match file names

### DIFF
--- a/src/ChainState.jsx
+++ b/src/ChainState.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 
 import { Grid, Form, Dropdown, Button, Input } from "semantic-ui-react";
 
-export default function Metadata(props) {
+export default function ChainState(props) {
   const { api } = props;
 
   const [modulesList, setModulesList] = useState([]);

--- a/src/Events.jsx
+++ b/src/Events.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 
 import { Feed, Grid } from "semantic-ui-react";
 
-export default function Metadata(props) {
+export default function Events(props) {
   const { api } = props;
 
   const [eventFeed, setEventFeed] = useState([]);

--- a/src/Extrinsics.jsx
+++ b/src/Extrinsics.jsx
@@ -4,7 +4,7 @@ import { Grid, Form, Dropdown, Input } from "semantic-ui-react";
 
 import TxButton from "./TxButton";
 
-export default function Metadata(props) {
+export default function Extrinsics(props) {
   const { api, accountPair } = props;
 
   const [modulesList, setModulesList] = useState([]);

--- a/src/Upgrade.jsx
+++ b/src/Upgrade.jsx
@@ -3,7 +3,7 @@ import { Form, Input, Grid } from "semantic-ui-react";
 
 import TxButton from "./TxButton";
 
-export default function Transfer(props) {
+export default function Upgrade(props) {
   const { api, accountPair } = props;
   const [status, setStatus] = useState("");
   const [proposal, setProposal] = useState({});


### PR DESCRIPTION
Renames the default exports of several files to match the component names and file names.