### PR TITLE
Template module

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -31,8 +31,9 @@ export default function App() {
   const [accountLoaded, setAccountLoaded] = useState(false);
   const [accountAddress, setAccountAddress] = useState("");
 
-  const WS_PROVIDER = "ws://127.0.0.1:9944";
-  //const WS_PROVIDER = "wss://dev-node.substrate.dev:9944";
+  //const WS_PROVIDER = "ws://134.209.196.6:9944";           // digital ocean node
+  const WS_PROVIDER = "ws://127.0.0.1:9944";                 // localhost
+  //const WS_PROVIDER = "wss://dev-node.substrate.dev:9944"; // play node (resets hourly)
 
   const accountPair = accountAddress && keyring.getPair(accountAddress);
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -31,9 +31,8 @@ export default function App() {
   const [accountLoaded, setAccountLoaded] = useState(false);
   const [accountAddress, setAccountAddress] = useState("");
 
-  //const WS_PROVIDER = "ws://134.209.196.6:9944";           // digital ocean node
-  const WS_PROVIDER = "ws://127.0.0.1:9944";                 // localhost
-  //const WS_PROVIDER = "wss://dev-node.substrate.dev:9944"; // play node (resets hourly)
+  const WS_PROVIDER = "ws://127.0.0.1:9944";
+  //const WS_PROVIDER = "wss://dev-node.substrate.dev:9944";
 
   const accountPair = accountAddress && keyring.getPair(accountAddress);
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,6 +14,7 @@ import Metadata from "./Metadata";
 import NodeInfo from "./NodeInfo";
 import Transfer from "./Transfer";
 import Upgrade from "./Upgrade";
+import TemplateModule from "./TemplateModule";
 import "semantic-ui-css/semantic.min.css";
 
 export default function App() {
@@ -111,6 +112,7 @@ export default function App() {
         <Grid.Row>
           <Transfer api={api} keyring={keyring} />
           <Upgrade api={api} keyring={keyring} />
+          <TemplateModule api={api} keyring={keyring} />
         </Grid.Row>
         <Grid.Row>
           <Extrinsics api={api} keyring={keyring} />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -22,7 +22,7 @@ import Metadata from "./Metadata";
 import NodeInfo from "./NodeInfo";
 import Transfer from "./Transfer";
 import Upgrade from "./Upgrade";
-import TemplateModule from "./TemplateModule";
+import TemplateModule from "./examples/TemplateModule";
 import "semantic-ui-css/semantic.min.css";
 
 export default function App() {
@@ -156,12 +156,14 @@ export default function App() {
           <Grid.Row>
             <Transfer api={api} accountPair={accountPair} />
             <Upgrade api={api} accountPair={accountPair} />
-            <TemplateModule api={api} accountPair={accountPair} />
           </Grid.Row>
           <Grid.Row>
             <Extrinsics api={api} accountPair={accountPair} />
             <ChainState api={api} />
             <Events api={api} />
+          </Grid.Row>
+          <Grid.Row>
+            { api.query.templateModule && <TemplateModule api={api} accountPair={accountPair} /> }
           </Grid.Row>
         </Grid>
         {/* These components don't render elements. */}

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -31,8 +31,8 @@ export default function App() {
   const [accountLoaded, setAccountLoaded] = useState(false);
   const [accountAddress, setAccountAddress] = useState("");
 
-  const WS_PROVIDER = "ws://127.0.0.1:9944";
-  //const WS_PROVIDER = "wss://dev-node.substrate.dev:9944";
+  //const WS_PROVIDER = "ws://127.0.0.1:9944";
+  const WS_PROVIDER = "wss://dev-node.substrate.dev:9944";
 
   const accountPair = accountAddress && keyring.getPair(accountAddress);
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -21,8 +21,8 @@ export default function App() {
   const [api, setApi] = useState();
   const [apiReady, setApiReady] = useState();
   const [accountLoaded, setaccountLoaded] = useState(false);
-  //const WS_PROVIDER = "ws://127.0.0.1:9944";
-  const WS_PROVIDER = "wss://dev-node.substrate.dev:9944";
+  const WS_PROVIDER = "ws://127.0.0.1:9944";
+  //const WS_PROVIDER = "wss://dev-node.substrate.dev:9944";
 
   useEffect(() => {
     const provider = new WsProvider(WS_PROVIDER);

--- a/src/TemplateModule.jsx
+++ b/src/TemplateModule.jsx
@@ -1,0 +1,87 @@
+import React, { useState } from "react";
+import { Form, Input, Grid, Card, Statistic } from "semantic-ui-react";
+
+import TxButton from "./TxButton";
+
+export default function Transfer(props) {
+  const { api, keyring } = props;
+  const [status, setStatus] = useState("");
+  const [proposal, setProposal] = useState({});
+  const initialState = {
+    addressFrom: ""
+  };
+  const [formState, setFormState] = useState(initialState);
+  const { addressFrom } = formState;
+  const adminPair = !!addressFrom && keyring.getPair(addressFrom);
+
+  const keyringOptions = keyring.getPairs().map(account => ({
+    key: account.address,
+    value: account.address,
+    text: account.meta.name.toUpperCase()
+  }));
+
+  let fileReader;
+
+  const bufferToHex = buffer => {
+    return Array.from(new Uint8Array(buffer))
+      .map(b => b.toString(16).padStart(2, "0"))
+      .join("");
+  };
+
+  const handleFileRead = e => {
+    const content = bufferToHex(fileReader.result);
+    const newProposal = api.tx.system.setCode(`0x${content}`);
+    setProposal(newProposal);
+  };
+
+  const handleFileChosen = file => {
+    fileReader = new FileReader();
+    fileReader.onloadend = handleFileRead;
+    fileReader.readAsArrayBuffer(file);
+  };
+
+  const onChange = (_, data) => {
+    setFormState(formState => {
+      return {
+        ...formState,
+        [data.state]: data.value
+      };
+    });
+  };
+
+  return (
+    <Grid.Column>
+      <h1>Template Module</h1>
+      <Card>
+      <Card.Content textAlign="center">
+        <Statistic
+          label="Current Value"
+          value={5}//TODO
+        />
+      </Card.Content>
+      </Card>
+      <Form>
+        <Form.Field>
+          <Input
+            type="number"
+            id="new_value"
+            label="New Value"
+            onChange={() => "TODO"}
+          />
+        </Form.Field>
+        <Form.Field>
+          <TxButton
+            api={api}
+            fromPair={adminPair}
+            label={"Store Something"}
+            params={[proposal]}
+            setStatus={setStatus}
+            tx={api.tx.sudo}
+            sudo={true}
+          />
+          {status}
+        </Form.Field>
+      </Form>
+    </Grid.Column>
+  );
+}

--- a/src/TemplateModule.jsx
+++ b/src/TemplateModule.jsx
@@ -8,12 +8,15 @@ export default function Transfer(props) {
 
   // The transaction submission status
   const [status, setStatus] = useState("");
+
+  // The currently stored value
   const [currentValue, setCurrentValue] = useState(0);
   const initialState = {
-    addressFrom: ""
+    addressFrom: "",
+    newValue: 0,
   };
   const [formState, setFormState] = useState(initialState);
-  const { addressFrom } = formState;
+  const { addressFrom, newValue } = formState;
   const adminPair = !!addressFrom && keyring.getPair(addressFrom);
 
   // This was leftover from the runtime upgrade example.
@@ -23,6 +26,15 @@ export default function Transfer(props) {
     value: account.address,
     text: account.meta.name.toUpperCase()
   }));
+
+  const onChange = (first, data) => {
+    setFormState(formState => {
+      return {
+        ...formState,
+        [data.state]: data.value
+      };
+    });
+  };
 
   useEffect(() => {
     let unsubscribe;
@@ -64,22 +76,20 @@ export default function Transfer(props) {
             placeholder="Select from your accounts"
             fluid
             label="From"
-            //onChange={onChange}
+            onChange={onChange}
             search
             selection
             state="addressFrom"
             options={keyringOptions}
-            value={addressFrom}
           />
         </Form.Field>
         <Form.Field>
           <Input
             type="number"
             id="new_value"
+            state="newValue"
             label="New Value"
-            // Nothing should happen when this changes.
-            // Do I even need to specify it?
-            //onChange={() => "TODO"}
+            onChange={onChange}
           />
         </Form.Field>
         <Form.Field>
@@ -87,7 +97,7 @@ export default function Transfer(props) {
             api={api}
             fromPair={adminPair}
             label={"Store Something"}
-            params={[42]}
+            params={[newValue]}
             setStatus={setStatus}
             tx={api.tx.templateModule.doSomething}
             sudo={false}

--- a/src/TemplateModule.jsx
+++ b/src/TemplateModule.jsx
@@ -41,13 +41,12 @@ export default function Transfer(props) {
     api.query.templateModule.something(newValue => {
       // The storage value is an Option<u32>
       // So we have to check whether it is None first
-      // https://stackoverflow.com/q/679915/4184410
-      if (Object.keys(newValue.raw).length === 0){
+      // There is also unwrapOr
+      if (newValue.isNone){
         setCurrentValue("<None>");
       }
       else{
-        // Not none, so we can access the raw value
-        setCurrentValue(newValue.raw.toNumber());
+        setCurrentValue(newValue.unwrap().toNumber());
       }
     }).then(unsub => {
       unsubscribe = unsub;

--- a/src/examples/TemplateModule.jsx
+++ b/src/examples/TemplateModule.jsx
@@ -32,7 +32,7 @@ export default function Transfer(props) {
 
     return () => unsubscribe && unsubscribe();
 
-  }, [api.query.templateModule, api.query.templateModule.something]);
+  }, [api.query.templateModule]);
 
 
   return (

--- a/src/examples/TemplateModule.jsx
+++ b/src/examples/TemplateModule.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { Form, Input, Grid, Card, Statistic } from "semantic-ui-react";
 
-import TxButton from "./TxButton";
+import TxButton from "../TxButton";
 
 export default function Transfer(props) {
   const { api, accountPair } = props;


### PR DESCRIPTION
During SCL on 9 September 2019 we wrote a UI component for interacting with the [template module](https://github.com/substrate-developer-hub/substrate-module-template/). This serves as a nice example for others building on the ui-template.

It is displayed only when a module named `templateModule` is installed in the runtime.

This PR will conflict (in a trivial way) with #33.